### PR TITLE
refactor CI workflow to allow write access for lint error annotations…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
         contents: read  # minimal permissions for checking out code
-    outputs:
-        lint-out: ${{ steps.lint-code.outputs.lint-out }}
-
+        checks: write #allow write access to checks to allow the action to annotate code with lint errors in the PR
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -61,15 +59,3 @@ jobs:
         with:
           version: latest
           problem-matchers: true
-
-        #   TODO: fix this, outputs.lint-out is empty
-      - name: Save lint output
-        if: failure()
-        run: echo "${{steps.lint-code.outputs.lint-out}}" > lint.out
-
-      - name: Upload lint report
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-            name: lint-report
-            path: lint.out


### PR DESCRIPTION
… and remove unused lint output saving steps