### PR TITLE
Support TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,23 @@ func main() {
         return nil
     })
 
-    g.ListenAndServe(":8080")
+    // Use the new Start function instead of ListenAndServe
+    g.Start(":8080")
+}
+```
+
+You can also start a secure server with TLS:
+
+```go
+package main
+
+import "github.com/dpouris/goster"
+
+func main() {
+    g := goster.NewServer()
+    
+    // Replace with actual certificate and key paths
+    g.StartTLS(":8443", "path/to/cert.pem", "path/to/key.pem")
 }
 ```
 

--- a/context.go
+++ b/context.go
@@ -70,7 +70,7 @@ func (c *Ctx) HTML(t string) (err error) {
 			// open template
 			file, err := os.Open(templatePaths[tmplId])
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%v\n", err)
+				fmt.Fprintln(os.Stderr, err)
 			}
 			defer file.Close()
 
@@ -88,7 +88,7 @@ func (c *Ctx) HTML(t string) (err error) {
 			contentType := getContentType(file.Name())
 			c.Response.Header().Set("Content-Type", contentType)
 
-			fmt.Fprintln(c.Response.ResponseWriter, t) // write response
+			fmt.Fprint(c.Response.ResponseWriter, t) // write response
 		}
 	}
 	return

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -33,12 +33,11 @@ func main() {
 
     // Define a route for GET /
     g.Get("/", func(ctx *goster.Ctx) error {
-        ctx.Text("Welcome to Goster!")
-        return nil
+        return ctx.Text("Welcome to Goster!")
     })
 
     // Start the server on port 8080
-    g.ListenAndServe(":8080")
+    g.Start(":8080")
 }
 ```
 
@@ -54,9 +53,25 @@ Open your browser (or use `curl`) and visit `http://localhost:8080`. You should 
 
 - We created a Goster server with `goster.NewServer()`. This gives us an instance `g` that will handle HTTP requests.
 - We added a route using `g.Get("/")`. The first argument is the path (`"/"` for the root). The second argument is a **handler function** that Goster will call when a request comes in for that path. Our handler function uses `ctx.Text` to send a plain-text response.
-- Finally, `g.ListenAndServe(":8080")` starts an HTTP server on port 8080 and begins listening for requests. Under the hood, this uses Go’s `http.ListenAndServe`, passing Goster’s router as the handler.
+- Finally, `g.Start(":8080")` starts an HTTP server on port 8080 and begins listening for requests. Under the hood, this uses Go’s `http.ListenAndServe`, passing Goster’s router as the handler.
 
 When you visited the URL, Goster received the request, matched it to the `/` route, and executed your handler, which wrote “Welcome to Goster!” back to the client.
+
+## Secure Server with TLS
+
+Goster also supports running an HTTPS server using TLS. For example, set up your certificate and key files and start the server with:
+
+```go
+package main
+
+import "github.com/dpouris/goster"
+
+func main() {
+    g := goster.NewServer()
+    // Replace with the actual paths to your certificate and key
+    g.StartTLS(":8443", "path/to/cert.pem", "path/to/key.pem")
+}
+```
 
 ## Next Steps
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,19 +8,19 @@ Welcome to the **Goster Documentation** directory. This README organizes and lin
   Setup instructions and a basic example to run your first Goster server.
   
 - [Routing](Routing.md)  
-  Learn how to define routes, use dynamic segments, and handle path parameters.
+  Learn how to define routes, dynamic segments, and path parameters.
   
 - [Templates](Templates.md)  
-  Information on setting the template directory, creating templates, and rendering them.
+  Configuring template directories and rendering views.
   
 - [Static Files](Static_Files.md)  
-  How to serve static assets like HTML, CSS, JavaScript, and images with Goster.
+  Serving assets through Goster.
   
 - [Middleware](Middleware.md)  
-  Guidance on adding middleware for logging, authentication, error handling, etc.
+  Applying global and route-specific middleware.
   
 - [Logging](Logging.md)  
-  Understand Goster's built-in logging, how to use it, and how to access request logs.
+  How Goster logs events and request data.
   
 - [Context and Responses](Context_and_Responses.md)  
-  Detailed explanation of Goster's context (`Ctx`), request reading, and response writing.
+  Handling incoming requests and constructing responses.

--- a/examples/basic/example_basic.go
+++ b/examples/basic/example_basic.go
@@ -21,5 +21,5 @@ func main() {
 		return nil
 	})
 
-	g.ListenAndServe(":8080")
+	g.Start(":8080")
 }

--- a/examples/dynamic_routes/example_dynamic_route.go
+++ b/examples/dynamic_routes/example_dynamic_route.go
@@ -35,5 +35,5 @@ func main() {
 		return nil
 	})
 
-	g.ListenAndServe(":8080")
+	g.Start(":8080")
 }

--- a/examples/html_template/example_html_template.go
+++ b/examples/html_template/example_html_template.go
@@ -21,5 +21,5 @@ func main() {
 		return nil
 	})
 
-	g.ListenAndServe(":8080")
+	g.Start(":8080")
 }

--- a/examples/json_response/example_json_response.go
+++ b/examples/json_response/example_json_response.go
@@ -17,5 +17,5 @@ func main() {
 		return nil
 	})
 
-	g.ListenAndServe(":8080")
+	g.Start(":8080")
 }

--- a/examples/middleware/example_middleware.go
+++ b/examples/middleware/example_middleware.go
@@ -20,5 +20,5 @@ func main() {
 		return nil
 	})
 
-	g.ListenAndServe(":8080")
+	g.Start(":8080")
 }

--- a/examples/query_params/example_query_params.go
+++ b/examples/query_params/example_query_params.go
@@ -17,5 +17,5 @@ func main() {
 		return nil
 	})
 
-	g.ListenAndServe(":8080")
+	g.Start(":8080")
 }

--- a/goster.go
+++ b/goster.go
@@ -78,11 +78,17 @@ func (g *Goster) StaticDir(dir string) (err error) {
 	return
 }
 
-// ListenAndServe starts listening for incoming requests on the specified port (e.g., ":8080").
-func (g *Goster) ListenAndServe(p string) {
+// Start starts listening for incoming requests on the specified port (e.g., ":8080").
+func (g *Goster) Start(p string) {
 	g.cleanUp()
 	LogInfo("LISTENING ON http://127.0.0.1"+p, g.Logger)
 	log.Fatal(http.ListenAndServe(p, g))
+}
+
+func (g *Goster) StartTLS(addr string, certFile string, keyFile string) {
+	g.cleanUp()
+	LogInfo("LISTENING ON https://127.0.0.1"+addr, g.Logger)
+	http.ListenAndServeTLS(addr, certFile, keyFile, g)
 }
 
 // ServeHTTP is the handler for incoming HTTP requests to the server.

--- a/goster.go
+++ b/goster.go
@@ -88,7 +88,7 @@ func (g *Goster) Start(p string) {
 func (g *Goster) StartTLS(addr string, certFile string, keyFile string) {
 	g.cleanUp()
 	LogInfo("LISTENING ON https://127.0.0.1"+addr, g.Logger)
-	http.ListenAndServeTLS(addr, certFile, keyFile, g)
+	log.Fatal(http.ListenAndServeTLS(addr, certFile, keyFile, g))
 }
 
 // ServeHTTP is the handler for incoming HTTP requests to the server.


### PR DESCRIPTION
refactor: support tls by adding StartTLS, wrapper of http.ListenAndServeTLS; rename ListenAndServe to Start for consistency and clarity